### PR TITLE
Added a strategy to discard redundant sampling at later stages of the app's lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,27 @@ getTimeSinceStartup().then((time) => {
   console.log(`Time since startup: ${time} ms`);
 });
 ```
+
+### Ensuring purity of your analytics data
+
+_This section is applicable to Android only_
+
+In case you're going to use this library for collecting the performance analytics, be aware to discard redundant samples which may sometimes pop up.
+
+Depending on which lifecycle hook you've attached your call to `getTimeSinceStartup()` you might receive redundant invocations, e.g. when the app is brought from bg to fg. Because the app isn't really starting up, the measured time can be unrealistic; such unrealistic samples adulterate your data and should be avoided.
+
+To enforce single-sampling strategy, create your package using constructor with parameter `true`:
+```java
+// Define package
+new RNStartupTimePackage(true)
+```
+then sample the startup time with catching the redundant invocation error:
+```jsx
+// when you app is ready:
+getTimeSinceStartup().then((time) => {
+  // Initial sample. Collect it for your analytics.
+})
+.catch((e) => {
+  // Redundant sample. Do nothing or print a log.
+});
+```

--- a/android/src/main/java/com/github/doomsower/RNStartupTimePackage.java
+++ b/android/src/main/java/com/github/doomsower/RNStartupTimePackage.java
@@ -14,9 +14,29 @@ import java.util.List;
 public class RNStartupTimePackage implements ReactPackage {
     private static final long START_MARK = SystemClock.uptimeMillis();
 
+    private boolean enforceSingleInvocation;
+
+    public RNStartupTimePackage() {
+        this(false);
+    }
+
+    /**
+     * When used for collecting the performance analytics, redundant samples adulterate the data.
+     * Redundant invocations may occur depending on the lifecycle event to which the sampling is attached,
+     * e.g. bringing the app forward from the background. In such case, the app is not actually
+     * started up but just shown, so the reported startup time may appear unrealistic. Such unrealistic
+     * samples are going to adulterate your data, hence should be avoided.
+     *
+     * @param enforceSingleInvocation use {@code true} to prevent the redundant readings. In case of a redundant call,
+     *                              a {@link IllegalStateException} is thrown which you can {@code catch} in your code.
+     */
+    public RNStartupTimePackage(boolean enforceSingleInvocation) {
+        this.enforceSingleInvocation = enforceSingleInvocation;
+    }
+
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new RNStartupTimeModule(reactContext, START_MARK));
+        return Arrays.<NativeModule>asList(new RNStartupTimeModule(reactContext, START_MARK, enforceSingleInvocation));
     }
 
     @Override


### PR DESCRIPTION
Fixing issue #9 on Android

The existing behavior is 100% preserved. Clients who want to enforce the single-sampling strategy should use new constructor with parameter `true`:
```
packages = asList(...
    new RNStartupTimePackage(true),
    ...);
```
Those clients who use old constructor shall enjoy the old behaviour without changes.