### PR TITLE
feat(android): add namespace to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace = 'com.github.doomsower'
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 


### PR DESCRIPTION
Trivial change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

Nicola mentioned also we shouldn't remove package attribute from AndroidManifest to not lose compatibility with AGP < 8. I don't think it's worth maintaining logic to remove that attribute contitionally since it will only cause a warning to users on AGP 8 and above. 
